### PR TITLE
Take the length header into account in Compress() return

### DIFF
--- a/Snappy.Sharp/SnappyCompressor.cs
+++ b/Snappy.Sharp/SnappyCompressor.cs
@@ -52,7 +52,8 @@ namespace Snappy.Sharp
         public int Compress(byte[] uncompressed, int uncompressedOffset, int uncompressedLength, byte[] compressed, int compressedOffset)
         {
             int compressedIndex = WriteUncomressedLength(compressed, compressedOffset, uncompressedLength);
-            return compressedIndex + CompressInternal(uncompressed, uncompressedOffset, uncompressedLength, compressed, compressedIndex);
+            int headLength = compressedIndex - compressedOffset;
+            return headLength + CompressInternal(uncompressed, uncompressedOffset, uncompressedLength, compressed, compressedIndex);
         }
 
         internal int CompressInternal(byte[] uncompressed, int uncompressedOffset, int uncompressedLength, byte[] compressed, int compressedOffset)


### PR DESCRIPTION
Compress was ignoring the length of the byte count varint when
returning the length of compressed data.

This reverts the change in 7642fd8d2dcc2737142e47ecfd8924df7a2b1a0a,
which would only be correct for very short uncompressed data
(<127 bytes).

Fixes issue #2.
