### PR TITLE
Fix decompression with nonzero compressedOffsets

### DIFF
--- a/Snappy.Sharp/SnappyDecompressor.cs
+++ b/Snappy.Sharp/SnappyDecompressor.cs
@@ -35,10 +35,10 @@ namespace Snappy.Sharp
 
         public byte[] Decompress(byte[] compressed, int compressedOffset, int compressedSize)
         {
-            var sizeHeader = ReadUncompressedLength(compressed, 0);
+            var sizeHeader = ReadUncompressedLength(compressed, compressedOffset);
             var data = new byte[sizeHeader[0]];
 
-            Decompress(compressed, compressedOffset + sizeHeader[1], compressedSize - sizeHeader[1], data, 0, data.Length);
+            Decompress(compressed, sizeHeader[1], compressedSize - sizeHeader[1], data, 0, data.Length);
 
             return data;
         }


### PR DESCRIPTION
Hi Jeff, here's another small fix that would be nice to land upstream: Decompress() was always decompressing from the start of its array.

Thanks!
