### PR TITLE
Removed unnecessary build configurations...

### DIFF
--- a/Snappy.Sharp.Test/Snappy.Sharp.Test.csproj
+++ b/Snappy.Sharp.Test/Snappy.Sharp.Test.csproj
@@ -29,41 +29,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <CodeAnalysisLogFile>bin\Debug\Snappy.Sharp.Test.dll.CodeAnalysisLog.xml</CodeAnalysisLogFile>
-    <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
-    <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <CodeAnalysisRuleSetDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\\Rule Sets</CodeAnalysisRuleSetDirectories>
-    <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
-    <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
-    <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
-    <WarningLevel>4</WarningLevel>
-    <Optimize>false</Optimize>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <CodeAnalysisLogFile>bin\Release\Snappy.Sharp.Test.dll.CodeAnalysisLog.xml</CodeAnalysisLogFile>
-    <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
-    <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <CodeAnalysisRuleSetDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\\Rule Sets</CodeAnalysisRuleSetDirectories>
-    <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
-    <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
-    <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Snappy.Sharp.sln
+++ b/Snappy.Sharp.sln
@@ -9,67 +9,41 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Snappy.Performance", "Snapp
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Debug|Mixed Platforms = Debug|Mixed Platforms
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Release|Any CPU = Release|Any CPU
-		Release|Mixed Platforms = Release|Mixed Platforms
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{1AEE7F12-AFA7-45B1-BBE8-A56AA4B3F9A1}.Debug|Any CPU.ActiveCfg = Debug|x64
-		{1AEE7F12-AFA7-45B1-BBE8-A56AA4B3F9A1}.Debug|Any CPU.Build.0 = Debug|x64
-		{1AEE7F12-AFA7-45B1-BBE8-A56AA4B3F9A1}.Debug|Mixed Platforms.ActiveCfg = Debug|x64
-		{1AEE7F12-AFA7-45B1-BBE8-A56AA4B3F9A1}.Debug|Mixed Platforms.Build.0 = Debug|x64
+		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Debug|x64.Build.0 = Debug|Any CPU
+		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Debug|x86.Build.0 = Debug|Any CPU
+		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Release|x64.ActiveCfg = Release|Any CPU
+		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Release|x64.Build.0 = Release|Any CPU
+		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Release|x86.ActiveCfg = Release|Any CPU
+		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Release|x86.Build.0 = Release|Any CPU
+		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Debug|x64.Build.0 = Debug|Any CPU
+		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Debug|x86.Build.0 = Debug|Any CPU
+		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Release|x64.ActiveCfg = Release|Any CPU
+		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Release|x64.Build.0 = Release|Any CPU
+		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Release|x86.ActiveCfg = Release|Any CPU
+		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Release|x86.Build.0 = Release|Any CPU
 		{1AEE7F12-AFA7-45B1-BBE8-A56AA4B3F9A1}.Debug|x64.ActiveCfg = Debug|x64
 		{1AEE7F12-AFA7-45B1-BBE8-A56AA4B3F9A1}.Debug|x64.Build.0 = Debug|x64
 		{1AEE7F12-AFA7-45B1-BBE8-A56AA4B3F9A1}.Debug|x86.ActiveCfg = Debug|x86
 		{1AEE7F12-AFA7-45B1-BBE8-A56AA4B3F9A1}.Debug|x86.Build.0 = Debug|x86
-		{1AEE7F12-AFA7-45B1-BBE8-A56AA4B3F9A1}.Release|Any CPU.ActiveCfg = Release|x64
-		{1AEE7F12-AFA7-45B1-BBE8-A56AA4B3F9A1}.Release|Any CPU.Build.0 = Release|x64
-		{1AEE7F12-AFA7-45B1-BBE8-A56AA4B3F9A1}.Release|Mixed Platforms.ActiveCfg = Release|x64
-		{1AEE7F12-AFA7-45B1-BBE8-A56AA4B3F9A1}.Release|Mixed Platforms.Build.0 = Release|x64
 		{1AEE7F12-AFA7-45B1-BBE8-A56AA4B3F9A1}.Release|x64.ActiveCfg = Release|x64
 		{1AEE7F12-AFA7-45B1-BBE8-A56AA4B3F9A1}.Release|x64.Build.0 = Release|x64
 		{1AEE7F12-AFA7-45B1-BBE8-A56AA4B3F9A1}.Release|x86.ActiveCfg = Release|x86
 		{1AEE7F12-AFA7-45B1-BBE8-A56AA4B3F9A1}.Release|x86.Build.0 = Release|x86
-		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Debug|x64.Build.0 = Debug|Any CPU
-		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Debug|x86.ActiveCfg = Debug|x86
-		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Debug|x86.Build.0 = Debug|x86
-		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Release|x64.ActiveCfg = Release|Any CPU
-		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Release|x86.ActiveCfg = Release|x86
-		{3DE0FF31-8A1D-4485-B725-D120CD91D205}.Release|x86.Build.0 = Release|x86
-		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Debug|x64.Build.0 = Debug|Any CPU
-		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Debug|x86.ActiveCfg = Debug|x86
-		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Debug|x86.Build.0 = Debug|x86
-		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Release|x64.ActiveCfg = Release|Any CPU
-		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Release|x86.ActiveCfg = Release|x86
-		{560D8F63-6927-46F6-856D-F28F02F2F1DC}.Release|x86.Build.0 = Release|x86
-	EndGlobalSection
-	GlobalSection(MonoDevelopProperties) = preSolution
-		StartupItem = Snappy.Performance\Snappy.Performance.csproj
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = Snappy.Performance\Snappy.Performance.csproj
 	EndGlobalSection
 EndGlobal

--- a/Snappy.Sharp/Snappy.Sharp.csproj
+++ b/Snappy.Sharp/Snappy.Sharp.csproj
@@ -31,44 +31,6 @@
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <CodeAnalysisLogFile>bin\Debug\Snappy.Sharp.dll.CodeAnalysisLog.xml</CodeAnalysisLogFile>
-    <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
-    <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <CodeAnalysisRuleSetDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\\Rule Sets</CodeAnalysisRuleSetDirectories>
-    <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
-    <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
-    <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
-    <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
-    <WarningLevel>4</WarningLevel>
-    <Optimize>false</Optimize>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <CodeAnalysisLogFile>bin\Release\Snappy.Sharp.dll.CodeAnalysisLog.xml</CodeAnalysisLogFile>
-    <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
-    <CodeAnalysisModuleSuppressionsFile>GlobalSuppressions.cs</CodeAnalysisModuleSuppressionsFile>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <CodeAnalysisRuleSetDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\\Rule Sets</CodeAnalysisRuleSetDirectories>
-    <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
-    <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
-    <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Removed unnecessary build configuration platform x86 for libraries.
(If a library is AnyCPU but the binary referencing them is compiled for x64 / x86, the libraries will be compiled for the same architecture.)
Removed confusing solution platforms "Any CPU" and "Mixed Platforms".